### PR TITLE
[semver:major] Added possibility to configure builder image tag for build job

### DIFF
--- a/src/executors/default.yml
+++ b/src/executors/default.yml
@@ -1,5 +1,12 @@
 description: >
   Default build executor
 docker:
-  - image: public.ecr.aws/y7n1s6r0/trading-dev-core-sdk:3.1
+  - image: 'public.ecr.aws/y7n1s6r0/trading-dev-core-sdk:<<parameters.tag>>'
 working_directory: /mnt/ramdisk
+parameters:
+  tag:
+    default: '3.1'
+    description: >
+      Pick a specific image tag:
+      https://gallery.ecr.aws/y7n1s6r0/trading-dev-core-sdk
+    type: string

--- a/src/jobs/build.yml
+++ b/src/jobs/build.yml
@@ -1,11 +1,17 @@
 description: >
   Runs Solution Build
 
-executor: default
+executor:
+  name: default
+  tag: <<parameters.builder_image_tag>>
 
 parameters:
   solution_path:
     description: Path to csproj file relative to project root
+    type: string
+  builder_image_tag:
+    default: '3.1'
+    description: Tag of builder image
     type: string
 
 steps:

--- a/src/jobs/nuget.yml
+++ b/src/jobs/nuget.yml
@@ -1,7 +1,9 @@
 description: >
   Pack NuGets
 
-executor: default
+executor:
+  name: default
+  tag: <<parameters.builder_image_tag>>
 
 parameters:
   namespaces:
@@ -12,6 +14,10 @@ parameters:
     type: string
   pipeline_id:
     type: integer
+  builder_image_tag:
+    default: '3.1'
+    description: Tag of builder image
+    type: string
 
 steps:
   - checkout

--- a/src/jobs/test.yml
+++ b/src/jobs/test.yml
@@ -1,7 +1,15 @@
 description: >
   Runs Unit Tests
 
-executor: default
+executor:
+  name: default
+  tag: <<parameters.builder_image_tag>>
+
+parameters:
+  builder_image_tag:
+    default: '3.1'
+    description: Tag of builder image
+    type: string
 
 steps:
   - checkout


### PR DESCRIPTION
Added "tag" parameter for "default" executor. Default value is '3.1'.
Added "builder_image_tag" parameter for "build", "nuget" and "test" jobs which is passed to executor.