### PR TITLE
[Off-story] Git fetch added to test steps

### DIFF
--- a/src/jobs/test-with-db.yml
+++ b/src/jobs/test-with-db.yml
@@ -18,6 +18,9 @@ steps:
   - start_postgresql_service
   - git-shallow-clone/checkout_advanced:
       clone_options: '--filter=blob:none'
+  - run:
+      name: "Git fetch"
+      command: git fetch --no-filter --refetch
   - dotnet_test:
       sonarscanner_project_key: <<parameters.sonarscanner_project_key>>
   - inject_slack_templates

--- a/src/jobs/test.yml
+++ b/src/jobs/test.yml
@@ -17,6 +17,7 @@ parameters:
 steps:
   - git-shallow-clone/checkout_advanced:
       clone_options: '--filter=blob:none'
+  - run: git fetch --no-filter --refetch
   - dotnet_test:
       sonarscanner_project_key: <<parameters.sonarscanner_project_key>>
   - inject_slack_templates

--- a/src/jobs/test.yml
+++ b/src/jobs/test.yml
@@ -17,7 +17,7 @@ parameters:
 steps:
   - git-shallow-clone/checkout_advanced:
       clone_options: '--filter=blob:none'
-  - run: 
+  - run:
       name: "Git fetch"
       command: git fetch --no-filter --refetch
   - dotnet_test:

--- a/src/jobs/test.yml
+++ b/src/jobs/test.yml
@@ -17,7 +17,9 @@ parameters:
 steps:
   - git-shallow-clone/checkout_advanced:
       clone_options: '--filter=blob:none'
-  - run: git fetch --no-filter --refetch
+  - run: 
+      name: "Git fetch"
+      command: git fetch --no-filter --refetch
   - dotnet_test:
       sonarscanner_project_key: <<parameters.sonarscanner_project_key>>
   - inject_slack_templates


### PR DESCRIPTION
We were getting a missing blob error during the test step. Ivan suggested adding a git fetch step between the git checkout and dotnet test commands. I added it in a separate branch of global-limits-service and tested it, and the new change fixed the error.

https://app.circleci.com/pipelines/github/coingaming/tradeart-global-limits-service/8/workflows/f5d92217-7bc6-41bb-8d0f-b5a5b68b45c0

Issue discussions on sonar and CircleCI forums.

https://community.sonarsource.com/t/missing-blob-jgit-error-with-sonarcloud/109574/8
https://discuss.circleci.com/t/product-update-speeding-up-code-checkout/50317/21