### PR TITLE
[Off-story] refactor: Installing required intent CLI during execution

### DIFF
--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -11,5 +11,5 @@ display:
   source_url: "https://github.com/coingaming/trading-team-orb"
 
 orbs:
-  slack: circleci/slack@4.2.1
+  slack: circleci/slack@5.1.1 # https://circleci.com/developer/orbs/orb/circleci/slack
   git-shallow-clone: guitarrapc/git-shallow-clone@2.8.0

--- a/src/commands/intent_check_staged.yml
+++ b/src/commands/intent_check_staged.yml
@@ -8,9 +8,17 @@ parameters:
   application_id:
     type: string
     default: ''
+  intent_version:
+    type: string
+    default: '4.4.5'
 steps:
   - run:
-      name: "Running SF CLI"
+      name: "Install Intent CLI"
+      command: |
+        dotnet tool install Intent.SoftwareFactory.CLI --global --version <<parameters.intent_version>>
+        PATH="${PATH}:/root/.dotnet/tools"
+  - run:
+      name: "Check Intent unstaged changes"
       command: |
         ssh-keyscan github.com >> ~/.ssh/known_hosts
         echo '-----BEGIN OPENSSH PRIVATE KEY-----' > ~/.ssh/id_rsa_1

--- a/src/jobs/intent_check.yml
+++ b/src/jobs/intent_check.yml
@@ -2,8 +2,8 @@ description: >
   Check Intent Architect project.
 
 executor:
-  name: intent
-  tag: <<parameters.intent_version>>
+  name: default
+  tag: "8.0"
 
 parameters:
   path_to_intent:
@@ -17,13 +17,14 @@ parameters:
   intent_version:
     description: Version of intent check tool required for the run.
     type: string
-    default: '4.3.4'
+    default: '4.4.5'
 
 steps:
   - checkout
   - intent_check_staged:
       path_to_intent: <<parameters.path_to_intent>>
       application_id: <<parameters.application_id>>
+      intent_version: <<parameters.intent_version>>
   - inject_slack_templates
   - slack/notify:
       event: fail


### PR DESCRIPTION
Allows to configure any version of intent CLI required without the need to recreate docker image.