### PR TITLE
Remove --debug from helm upgrade (avoid leaking values in CI logs)

### DIFF
--- a/src/commands/deploy_using_helm.yml
+++ b/src/commands/deploy_using_helm.yml
@@ -38,4 +38,4 @@ steps:
         helm upgrade --install -n $HELM_NAMESPACE \
          --timeout << parameters.helm_timeout >> \
          --set image.repository=178636341549.dkr.ecr.eu-central-1.amazonaws.com/<< parameters.repository_name >> \
-         --set image.tag=$FULL_VERSION << parameters.kube_service_name >> ./helm --debug --atomic
+         --set image.tag=$FULL_VERSION << parameters.kube_service_name >> ./helm --atomic

--- a/src/commands/deploy_using_helm_tenanted.yml
+++ b/src/commands/deploy_using_helm_tenanted.yml
@@ -44,4 +44,4 @@ steps:
         helm upgrade --install -n $HELM_NAMESPACE \
          --timeout << parameters.helm_timeout >> \
          --set image.repository=178636341549.dkr.ecr.eu-central-1.amazonaws.com/<< parameters.repository_name >> \
-         --set image.tag=$FULL_VERSION << parameters.kube_service_name >> ./helm --debug --atomic
+         --set image.tag=$FULL_VERSION << parameters.kube_service_name >> ./helm --atomic


### PR DESCRIPTION
## What
Drop `--debug` from the `helm upgrade --install` call in both deploy commands:

- `src/commands/deploy_using_helm.yml`
- `src/commands/deploy_using_helm_tenanted.yml`

`--atomic` is kept.

## Why
On upgrade, `helm --debug` prints the fully rendered chart plus the merged values to the CircleCI build log. Any secret carried in a values file is therefore exposed to anyone with read access to the pipeline. Removing `--debug` closes that leak without changing deploy behaviour (`--atomic` still rolls back on failure).

## Scope / notes
- Only the **deploy (helm upgrade)** path is touched here.
- `--debug` is still present on the `helm lint` commands (`lint_helm.yml`, `lint_helm_tenanted.yml`). Lint output is lower-risk (chart diagnostics rather than merged release values), so it's left as a possible follow-up rather than bundled in.
- No functional change to what gets deployed.