### PR TITLE
[Off-story] Ci: Add build_and_test and publish_host jobs, configurable DLC

### DIFF
--- a/src/commands/build_and_test.yml
+++ b/src/commands/build_and_test.yml
@@ -21,15 +21,7 @@ parameters:
     type: boolean
 
 steps:
-  - run:
-      name: "Preparing NuGet cache key"
-      command: |
-        find . \( -name '*.csproj' -o -name 'packages.lock.json' \) -print0 \
-          | sort -z | xargs -0 cat 2>/dev/null | sha256sum | cut -d' ' -f1 > /tmp/nuget-cache-key || echo "nolock" > /tmp/nuget-cache-key
-  - restore_cache:
-      keys:
-        - dotnet-nuget-v1-{{ checksum "/tmp/nuget-cache-key" }}
-        - dotnet-nuget-v1-
+  - restore_nuget_cache
   - run:
       name: "Restoring packages"
       command: dotnet restore
@@ -75,16 +67,7 @@ steps:
               else
                 dotnet sonarscanner end /d:sonar.login=$SONAR_TOKEN
               fi
-  - run:
-      name: "Convert test results"
-      when: always
-      command: |
-        find -regex ".*\/TestResults\/.+\.trx$" -not -type d
-        mkdir -p tests/TestResultsRaw/
-        find -regex ".*\/TestResults\/.+\.trx$" -not -type d -exec cp "{}" ./tests/TestResultsRaw/ ";"
-        trx2junit ./tests/TestResultsRaw/*.trx  --output ./tests/TestResults
-  - store_test_results:
-      path: tests/TestResults
+  - convert_test_results
   - when:
       condition: <<parameters.namespaces>>
       steps:
@@ -103,6 +86,5 @@ steps:
   - when:
       condition: <<parameters.project_path>>
       steps:
-        - run:
-            name: "Publishing solution"
-            command: dotnet publish <<parameters.project_path>> --no-build -c Release -o app/out
+        - publish_solution_nobuild:
+            project_path: <<parameters.project_path>>

--- a/src/commands/build_and_test.yml
+++ b/src/commands/build_and_test.yml
@@ -1,0 +1,108 @@
+description: >
+  Restore, build, test and optionally pack NuGets and publish. Compiles the
+  solution once and reuses it for test/pack/publish via --no-build.
+
+parameters:
+  project_path:
+    description: Host csproj to publish to app/out. Empty for library repos (test + pack only).
+    type: string
+    default: ""
+  namespaces:
+    description: Space-separated projects to pack as NuGets. Empty skips packing.
+    type: string
+    default: ""
+  sonarscanner_project_key:
+    description: Project Key For SonarScanner. Empty skips Sonar.
+    type: string
+    default: ""
+  run_marten_codegen:
+    default: false
+    description: Set this to true for projects that implement code generation for Marten
+    type: boolean
+
+steps:
+  - run:
+      name: "Preparing NuGet cache key"
+      command: |
+        find . \( -name '*.csproj' -o -name 'packages.lock.json' \) -print0 \
+          | sort -z | xargs -0 cat 2>/dev/null | sha256sum | cut -d' ' -f1 > /tmp/nuget-cache-key || echo "nolock" > /tmp/nuget-cache-key
+  - restore_cache:
+      keys:
+        - dotnet-nuget-v1-{{ checksum "/tmp/nuget-cache-key" }}
+        - dotnet-nuget-v1-
+  - run:
+      name: "Restoring packages"
+      command: dotnet restore
+  - save_cache:
+      key: dotnet-nuget-v1-{{ checksum "/tmp/nuget-cache-key" }}
+      paths:
+        - ~/.nuget/packages
+  - when:
+      condition: <<parameters.sonarscanner_project_key>>
+      steps:
+        - run:
+            name: "Sonar begin"
+            command: |
+              # Sonar runs on feature branches and master, skipped on staging/release.
+              if [ "$CIRCLE_BRANCH" = "staging" ] || [ "$CIRCLE_BRANCH" = "release" ]; then
+                echo "Skipping Sonar on $CIRCLE_BRANCH"
+              else
+                dotnet sonarscanner begin /k:"<<parameters.sonarscanner_project_key>>" /d:sonar.login=$SONAR_TOKEN /d:sonar.host.url=https://sonarcloud.io /o:"coingaming" /d:sonar.verbose=false /d:sonar.cs.opencover.reportsPaths="**/coverage.opencover.xml" /d:sonar.coverage.exclusions="**Tests*.cs,**/Migrations/*.cs,**/Startup.cs,**Program.cs,**Startup.cs"
+              fi
+  - when:
+      condition: <<parameters.run_marten_codegen>>
+      steps:
+        - run:
+            name: "Running Marten codegen"
+            command: dotnet run --project <<parameters.project_path>> -- codegen write
+  - run:
+      name: "Building solution"
+      command: |
+        apt-get update && apt-get install libunwind8 libxml2 -y
+        dotnet build -c Release --no-restore
+  - run:
+      name: "Running tests"
+      command: |
+        dotnet test --no-build --no-restore -c Release --logger "trx" --logger "console;verbosity=detailed" --collect "XPlat Code Coverage" -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.SplitCoverage="True" -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=opencover
+  - when:
+      condition: <<parameters.sonarscanner_project_key>>
+      steps:
+        - run:
+            name: "Sonar end"
+            command: |
+              if [ "$CIRCLE_BRANCH" = "staging" ] || [ "$CIRCLE_BRANCH" = "release" ]; then
+                echo "Skipping Sonar on $CIRCLE_BRANCH"
+              else
+                dotnet sonarscanner end /d:sonar.login=$SONAR_TOKEN
+              fi
+  - run:
+      name: "Convert test results"
+      when: always
+      command: |
+        find -regex ".*\/TestResults\/.+\.trx$" -not -type d
+        mkdir -p tests/TestResultsRaw/
+        find -regex ".*\/TestResults\/.+\.trx$" -not -type d -exec cp "{}" ./tests/TestResultsRaw/ ";"
+        trx2junit ./tests/TestResultsRaw/*.trx  --output ./tests/TestResults
+  - store_test_results:
+      path: tests/TestResults
+  - when:
+      condition: <<parameters.namespaces>>
+      steps:
+        - run:
+            name: "Packing and pushing Nugets"
+            command: |
+              # NuGets are published from feature branches and master, not staging/release.
+              if [ "$CIRCLE_BRANCH" = "staging" ] || [ "$CIRCLE_BRANCH" = "release" ]; then
+                echo "Skipping NuGet publish on $CIRCLE_BRANCH"
+              else
+                for i in <<parameters.namespaces>>; do
+                  dotnet pack $i --no-build -c Release --output /app/nupkgs -p:VersionSuffix=$NUGET_VERSION_SUFFIX -p:VersionPrefix=$VERSION_PREFIX
+                done
+                dotnet nuget push /app/nupkgs/ --source "nuget/Main" --skip-duplicate
+              fi
+  - when:
+      condition: <<parameters.project_path>>
+      steps:
+        - run:
+            name: "Publishing solution"
+            command: dotnet publish <<parameters.project_path>> --no-build -c Release -o app/out

--- a/src/commands/convert_test_results.yml
+++ b/src/commands/convert_test_results.yml
@@ -1,0 +1,15 @@
+description: >
+  Collect .trx test results and convert them to JUnit so CircleCI can render
+  the test summary. Runs on both pass and fail.
+
+steps:
+  - run:
+      name: "Convert test results"
+      when: always
+      command: |
+        find -regex ".*\/TestResults\/.+\.trx$" -not -type d
+        mkdir -p tests/TestResultsRaw/
+        find -regex ".*\/TestResults\/.+\.trx$" -not -type d -exec cp "{}" ./tests/TestResultsRaw/ ";"
+        trx2junit ./tests/TestResultsRaw/*.trx  --output ./tests/TestResults
+  - store_test_results:
+      path: tests/TestResults

--- a/src/commands/dotnet_test.yml
+++ b/src/commands/dotnet_test.yml
@@ -14,13 +14,4 @@ steps:
         dotnet build
         dotnet test --logger "trx" --logger "console;verbosity=detailed" --collect "XPlat Code Coverage" -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.SplitCoverage="True" -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=opencover
         dotnet sonarscanner end /d:sonar.login=$SONAR_TOKEN
-  - run:
-      name: "Convert test results"
-      when: always
-      command: |
-        find -regex ".*\/TestResults\/.+\.trx$" -not -type d
-        mkdir -p tests/TestResultsRaw/
-        find -regex ".*\/TestResults\/.+\.trx$" -not -type d -exec cp "{}" ./tests/TestResultsRaw/ ";"
-        trx2junit ./tests/TestResultsRaw/*.trx  --output ./tests/TestResults
-  - store_test_results:
-      path: tests/TestResults
+  - convert_test_results

--- a/src/commands/publish_host.yml
+++ b/src/commands/publish_host.yml
@@ -12,15 +12,6 @@ parameters:
 steps:
   # publish --no-build still needs ~/.nuget/packages to assemble the output, and
   # that cache doesn't travel in the workspace — so restore it here first.
-  - run:
-      name: "Preparing NuGet cache key"
-      command: |
-        find . \( -name '*.csproj' -o -name 'packages.lock.json' \) -print0 \
-          | sort -z | xargs -0 cat 2>/dev/null | sha256sum | cut -d' ' -f1 > /tmp/nuget-cache-key || echo "nolock" > /tmp/nuget-cache-key
-  - restore_cache:
-      keys:
-        - dotnet-nuget-v1-{{ checksum "/tmp/nuget-cache-key" }}
-        - dotnet-nuget-v1-
-  - run:
-      name: "Publishing solution"
-      command: dotnet publish <<parameters.project_path>> --no-build -c Release -o app/out
+  - restore_nuget_cache
+  - publish_solution_nobuild:
+      project_path: <<parameters.project_path>>

--- a/src/commands/publish_host.yml
+++ b/src/commands/publish_host.yml
@@ -10,6 +10,17 @@ parameters:
     type: string
 
 steps:
+  # publish --no-build still needs ~/.nuget/packages to assemble the output, and
+  # that cache doesn't travel in the workspace — so restore it here first.
+  - run:
+      name: "Preparing NuGet cache key"
+      command: |
+        find . \( -name '*.csproj' -o -name 'packages.lock.json' \) -print0 \
+          | sort -z | xargs -0 cat 2>/dev/null | sha256sum | cut -d' ' -f1 > /tmp/nuget-cache-key || echo "nolock" > /tmp/nuget-cache-key
+  - restore_cache:
+      keys:
+        - dotnet-nuget-v1-{{ checksum "/tmp/nuget-cache-key" }}
+        - dotnet-nuget-v1-
   - run:
       name: "Publishing solution"
-      command: dotnet publish <<parameters.project_path>> --no-build --no-restore -c Release -o app/out
+      command: dotnet publish <<parameters.project_path>> --no-build -c Release -o app/out

--- a/src/commands/publish_host.yml
+++ b/src/commands/publish_host.yml
@@ -1,0 +1,15 @@
+description: >
+  Publish a single host to app/out, reusing the compile from build_and_test
+  (via --no-build). Use this when multi-host repos so every host is published from
+  one shared build instead of recompiling per host.
+  Ensure to set build_and_test.persist_build: true
+
+parameters:
+  project_path:
+    description: Host csproj to publish to app/out.
+    type: string
+
+steps:
+  - run:
+      name: "Publishing solution"
+      command: dotnet publish <<parameters.project_path>> --no-build --no-restore -c Release -o app/out

--- a/src/commands/publish_solution_nobuild.yml
+++ b/src/commands/publish_solution_nobuild.yml
@@ -1,0 +1,14 @@
+description: >
+  Publish a project to app/out reusing an existing compile (--no-build).
+  Requires the compiled tree to be present (same job as build_and_test, or a
+  workspace attached from it) and ~/.nuget/packages restored.
+
+parameters:
+  project_path:
+    description: Host csproj to publish to app/out.
+    type: string
+
+steps:
+  - run:
+      name: "Publishing solution"
+      command: dotnet publish <<parameters.project_path>> --no-build -c Release -o app/out

--- a/src/commands/restore_nuget_cache.yml
+++ b/src/commands/restore_nuget_cache.yml
@@ -1,0 +1,16 @@
+description: >
+  Compute a NuGet cache key from every csproj/lock file and restore the
+  ~/.nuget/packages cache. Does not save — the job that populates the cache
+  (build_and_test) saves after `dotnet restore` using the same
+  /tmp/nuget-cache-key this command writes.
+
+steps:
+  - run:
+      name: "Preparing NuGet cache key"
+      command: |
+        find . \( -name '*.csproj' -o -name 'packages.lock.json' \) -print0 \
+          | sort -z | xargs -0 cat 2>/dev/null | sha256sum | cut -d' ' -f1 > /tmp/nuget-cache-key || echo "nolock" > /tmp/nuget-cache-key
+  - restore_cache:
+      keys:
+        - dotnet-nuget-v1-{{ checksum "/tmp/nuget-cache-key" }}
+        - dotnet-nuget-v1-

--- a/src/jobs/build_and_test.yml
+++ b/src/jobs/build_and_test.yml
@@ -43,9 +43,9 @@ parameters:
     default: false
     description: Start the local PostgreSQL service before tests (needs a *-db builder image).
     type: boolean
-  setup_remote_docker:
+  test_containers_required:
     default: true
-    description: Set up remote Docker for integration tests.
+    description: Set true when tests launch Docker containers (Testcontainers or raw Docker) — provisions remote Docker. Not needed for pure unit tests or in-image DB tests (with_db).
     type: boolean
   docker_layer_caching:
     default: true
@@ -67,9 +67,9 @@ steps:
       name: "Git fetch"
       command: git fetch --no-filter --refetch
   - when:
-      condition: <<parameters.setup_remote_docker>>
+      condition: <<parameters.test_containers_required>>
       steps:
-        - setup_remote_docker: # For integration tests
+        - setup_remote_docker: # provisioned only when tests launch containers
             docker_layer_caching: <<parameters.docker_layer_caching>>
   - when:
       condition: <<parameters.namespaces>>

--- a/src/jobs/build_and_test.yml
+++ b/src/jobs/build_and_test.yml
@@ -1,0 +1,103 @@
+description: >
+  Build, test and optionally pack + publish in a single job (compiles once,
+  reuses via --no-build). Opt-in replacement for the test + build + nuget jobs.
+
+executor:
+  name: default
+  tag: <<parameters.builder_image_tag>>
+  resource_class: <<parameters.executor_class>>
+
+parameters:
+  builder_image_tag:
+    default: '9.0'
+    description: Tag of builder image
+    type: string
+  executor_class:
+    default: 'medium'
+    type: string
+  project_path:
+    description: Host csproj to publish to app/out. Empty for library repos (test + pack only).
+    type: string
+    default: ""
+  namespaces:
+    description: Space-separated projects to pack as NuGets. Empty skips packing.
+    type: string
+    default: ""
+  sonarscanner_project_key:
+    description: Project Key For SonarScanner. Empty skips Sonar.
+    type: string
+    default: ""
+  base_version:
+    description: Base version, required when namespaces is set.
+    type: string
+    default: ""
+  pipeline_id:
+    description: Pipeline number used in the NuGet version, required when namespaces is set.
+    type: integer
+    default: 0
+  run_marten_codegen:
+    default: false
+    description: Set this to true for projects that implement code generation for Marten
+    type: boolean
+  with_db:
+    default: false
+    description: Start the local PostgreSQL service before tests (needs a *-db builder image).
+    type: boolean
+  setup_remote_docker:
+    default: true
+    description: Set up remote Docker for integration tests.
+    type: boolean
+  docker_layer_caching:
+    default: true
+    description: Docker layer caching — a paid ~200 credit/job feature. On by default to keep existing behaviour; set false per project to save ~200 credits/run when in-test image pulls/builds are light.
+    type: boolean
+  persist_build:
+    default: false
+    description: Persist the compiled tree so separate publish jobs can reuse it (--no-build). Set true for multi-host repos.
+    type: boolean
+
+steps:
+  - when:
+      condition: <<parameters.with_db>>
+      steps:
+        - start_postgresql_service
+  - git-shallow-clone/checkout_advanced:
+      clone_options: '--filter=blob:none'
+  - run:
+      name: "Git fetch"
+      command: git fetch --no-filter --refetch
+  - when:
+      condition: <<parameters.setup_remote_docker>>
+      steps:
+        - setup_remote_docker: # For integration tests
+            docker_layer_caching: <<parameters.docker_layer_caching>>
+  - when:
+      condition: <<parameters.namespaces>>
+      steps:
+        - inject_version_data:
+            base_version: <<parameters.base_version>>
+            pipeline_id: <<parameters.pipeline_id>>
+  - build_and_test:
+      project_path: <<parameters.project_path>>
+      namespaces: <<parameters.namespaces>>
+      sonarscanner_project_key: <<parameters.sonarscanner_project_key>>
+      run_marten_codegen: <<parameters.run_marten_codegen>>
+  # Persists the whole tree (parity with build job): needed when this job
+  # publishes inline (project_path) or when downstream publish jobs will reuse
+  # the compiled tree (persist_build). Docker builds -f CircleDockerfile . and
+  # some Dockerfiles COPY more than app/out, so the whole tree is kept.
+  - when:
+      condition:
+        or:
+          - <<parameters.project_path>>
+          - <<parameters.persist_build>>
+      steps:
+        - persist_to_workspace:
+            root: ./
+            paths:
+              - .
+  - inject_slack_templates
+  - slack/notify:
+      event: fail
+      template: BUILD_FAILED_TEMPLATE
+      channel: odds88-circleci-notifications

--- a/src/jobs/publish_host.yml
+++ b/src/jobs/publish_host.yml
@@ -1,0 +1,37 @@
+description: >
+  Publish one host from the shared build_and_test compile (--no-build) and hand
+  the result to a docker job. Requires a build_and_test job run with
+  persist_build: true. One publish_host per host keeps each docker job's
+  workspace to a single app/out (no collision).
+
+executor:
+  name: default
+  tag: <<parameters.builder_image_tag>>
+  resource_class: <<parameters.executor_class>>
+
+parameters:
+  builder_image_tag:
+    default: '9.0'
+    description: Tag of builder image
+    type: string
+  executor_class:
+    default: 'small'
+    type: string
+  project_path:
+    description: Host csproj to publish to app/out.
+    type: string
+
+steps:
+  - attach_workspace:
+      at: ./
+  - publish_host:
+      project_path: <<parameters.project_path>>
+  - persist_to_workspace:
+      root: ./
+      paths:
+        - .
+  - inject_slack_templates
+  - slack/notify:
+      event: fail
+      template: BUILD_FAILED_TEMPLATE
+      channel: odds88-circleci-notifications

--- a/src/jobs/test-with-db.yml
+++ b/src/jobs/test-with-db.yml
@@ -13,6 +13,10 @@ parameters:
   sonarscanner_project_key:
     description: Project Key For SonarScanner
     type: string
+  docker_layer_caching:
+    default: true
+    description: Docker layer caching — a paid ~200 credit/job feature. On by default to keep existing behaviour; set false per project to save ~200 credits/run when in-test image pulls/builds are light.
+    type: boolean
 
 steps:
   - start_postgresql_service
@@ -22,7 +26,7 @@ steps:
       name: "Git fetch"
       command: git fetch --no-filter --refetch
   - setup_remote_docker: # For integration tests
-      docker_layer_caching: true
+      docker_layer_caching: <<parameters.docker_layer_caching>>
   - dotnet_test:
       sonarscanner_project_key: <<parameters.sonarscanner_project_key>>
   - inject_slack_templates

--- a/src/jobs/test.yml
+++ b/src/jobs/test.yml
@@ -17,6 +17,10 @@ parameters:
   sonarscanner_project_key:
     description: Project Key For SonarScanner
     type: string
+  docker_layer_caching:
+    default: true
+    description: Docker layer caching — a paid ~200 credit/job feature. On by default to keep existing behaviour; set false per project to save ~200 credits/run when in-test image pulls/builds are light.
+    type: boolean
 
 steps:
   - git-shallow-clone/checkout_advanced:
@@ -25,7 +29,7 @@ steps:
       name: "Git fetch"
       command: git fetch --no-filter --refetch
   - setup_remote_docker: # For integration tests
-      docker_layer_caching: true
+      docker_layer_caching: <<parameters.docker_layer_caching>>
   - dotnet_test:
       sonarscanner_project_key: <<parameters.sonarscanner_project_key>>
   - inject_slack_templates


### PR DESCRIPTION
## What
Adds an opt-in consolidated CI flow to the orb and makes Docker Layer Caching configurable. The existing `test`, `build` and `nuget` jobs are unchanged, so bumping the orb is a no-op until a repo migrates.

### build_and_test
Compiles the solution once and reuses it for test, pack and publish via `--no-build`. Previously `test`, `build` and `nuget` each restored and recompiled the whole solution. Also adds NuGet package caching, and skips Sonar and NuGet publish on `staging`/`release` (they run on feature branches and master).

### publish_host (multi-host repos)
Publishes one host from `build_and_test`'s shared compile. Multi-image repos set `build_and_test.persist_build: true` and add one `publish_host` per host, so each `docker` job gets its own `app/out` with no workspace collision. Single-host repos don't need it — `build_and_test` publishes inline via `project_path`.

### project_path
The new `build_and_test` and `publish_host` take `project_path` (the host `.csproj` to publish) instead of the misnamed `solution_path`. The legacy `build`/`lambda_build` jobs keep `solution_path` for back-compat.

### Docker layer caching (configurable)
`docker_layer_caching` is now a parameter on `test`, `test-with-db` and `build_and_test`. It defaults to `true` to preserve current behaviour; set it to `false` per project to drop the paid DLC charge (~200 credits/run) where in-test image pulls are light. `setup_remote_docker` stays, so integration tests keep working.