### PR TITLE
[Off-story] Ci: Make docker layer caching opt-in on test jobs (default off)

### DIFF
--- a/src/jobs/test-with-db.yml
+++ b/src/jobs/test-with-db.yml
@@ -22,7 +22,7 @@ steps:
       name: "Git fetch"
       command: git fetch --no-filter --refetch
   - setup_remote_docker: # For integration tests
-      docker_layer_caching: true
+      docker_layer_caching: false
   - dotnet_test:
       sonarscanner_project_key: <<parameters.sonarscanner_project_key>>
   - inject_slack_templates

--- a/src/jobs/test-with-db.yml
+++ b/src/jobs/test-with-db.yml
@@ -13,6 +13,14 @@ parameters:
   sonarscanner_project_key:
     description: Project Key For SonarScanner
     type: string
+  docker_layer_caching:
+    default: false
+    description: >
+      Docker layer caching, billed at a flat ~200 credits per job run. Off by
+      default: dotnet_test runs no docker build, so the cache only ever absorbs
+      Testcontainers image pulls, which cost a few credits to redo. Set true per
+      project if those pulls prove expensive.
+    type: boolean
 
 steps:
   - start_postgresql_service
@@ -22,7 +30,7 @@ steps:
       name: "Git fetch"
       command: git fetch --no-filter --refetch
   - setup_remote_docker: # For integration tests
-      docker_layer_caching: false
+      docker_layer_caching: <<parameters.docker_layer_caching>>
   - dotnet_test:
       sonarscanner_project_key: <<parameters.sonarscanner_project_key>>
   - inject_slack_templates

--- a/src/jobs/test.yml
+++ b/src/jobs/test.yml
@@ -25,7 +25,7 @@ steps:
       name: "Git fetch"
       command: git fetch --no-filter --refetch
   - setup_remote_docker: # For integration tests
-      docker_layer_caching: true
+      docker_layer_caching: false
   - dotnet_test:
       sonarscanner_project_key: <<parameters.sonarscanner_project_key>>
   - inject_slack_templates

--- a/src/jobs/test.yml
+++ b/src/jobs/test.yml
@@ -17,6 +17,14 @@ parameters:
   sonarscanner_project_key:
     description: Project Key For SonarScanner
     type: string
+  docker_layer_caching:
+    default: false
+    description: >
+      Docker layer caching, billed at a flat ~200 credits per job run. Off by
+      default: dotnet_test runs no docker build, so the cache only ever absorbs
+      Testcontainers image pulls, which cost a few credits to redo. Set true per
+      project if those pulls prove expensive.
+    type: boolean
 
 steps:
   - git-shallow-clone/checkout_advanced:
@@ -25,7 +33,7 @@ steps:
       name: "Git fetch"
       command: git fetch --no-filter --refetch
   - setup_remote_docker: # For integration tests
-      docker_layer_caching: false
+      docker_layer_caching: <<parameters.docker_layer_caching>>
   - dotnet_test:
       sonarscanner_project_key: <<parameters.sonarscanner_project_key>>
   - inject_slack_templates


### PR DESCRIPTION
## What

Expose `docker_layer_caching` as a parameter on the two orb jobs that hardcode it on, and set the default to **`false`**:

- `src/jobs/test.yml`
- `src/jobs/test-with-db.yml`

Every consumer stops paying the surcharge on the next orb publish with no config changes. Any repo that genuinely regresses sets `docker_layer_caching: true` in its own config — no orb revert needed.

```yaml
  docker_layer_caching:
    default: false
    type: boolean
...
  - setup_remote_docker: # For integration tests
      docker_layer_caching: <<parameters.docker_layer_caching>>
```

## Why

DLC is billed at a **flat 200 credits per job run**, on top of compute. Both test jobs turn it on unconditionally, but `dotnet_test` never runs `docker build` — it runs `dotnet build` / `dotnet test` / sonarscanner. The only Docker activity is Testcontainers image *pulls* in a minority of repos, and redoing a pull costs single-digit credits against the 200 the cache surcharge costs.

Measured from the CircleCI Insights API, `reporting-window=last-90-days&all-branches=true`, across all 41 repos that invoke these jobs — 31 had runs:

| repo | test runs | credits/run | DLC share of run | DLC share of whole pipeline |
|---|---|---|---|---|
| tradeart-feedfactory | 193 | 292 | 68% | 62% |
| tradeart-feed-integration-common | 180 | 243 | 82% | 84% |
| tradeart-client-api | 172 | 230 | 87% | 74% |
| goat-backoffice-api | 162 | 243 | 82% | 72% |
| tradeart-betplacement | 119 | 279 | 72% | 68% |
| goat-lsport-integration | 105 | 238 | 84% | 77% |
| tradeart-templates-service | 105 | 254 | 79% | 73% |
| tradeart-oddsjam-integration | 104 | 224 | 89% | 82% |
| goat-betsview | 93 | 284 | 70% | 63% |
| goat-common | 92 | 731 | 27% | 27% |
| tradeart-exefeed-integration | 87 | 227 | 88% | 80% |
| tradeart-feedcore | 87 | 273 | 73% | 70% |
| …19 more repos | 397 | ~230 | ~87% | ~78% |
| **total (31 repos)** | **1,896** | **284** | **70%** | **65%** |

- **379,200 credits** of DLC surcharge in 90 days.
- That is **65% of every CI credit those repos spent**, across all jobs and all workflows.
- Run rate: ~126,400 credits/month, ~1.54M/year — roughly **$76/month, $920/year** at $0.0006/credit.
- The test job is the dominant job in nearly every pipeline; `build`, `docker`, `nuget` and the deploy jobs are 1–5% each.

Cross-check on `tradeart-feedfactory`: the Test job bills 292 credits/run at a 628s median on `medium` (~105 credits of compute). The missing ~190 is the DLC surcharge.

The two repos where DLC is a minority of the bill are `goat-common` (27%) and `goat-schema` (24%) — both have very long test jobs (731 and 841 credits/run), and `goat-schema` additionally overrides `executor_class: 'xlarge'`. Those are separate right-sizing fixes in their own configs.

## Does this break integration tests?

No. `setup_remote_docker` is what provisions the Docker daemon; `docker_layer_caching` only pre-seeds that daemon's layer cache, and `false` is CircleCI's own default for the key. `setup_remote_docker` is untouched, so any suite needing a daemon still gets one.

Checked, rather than assumed:

- `src/jobs/docker.yml:26` and `src/jobs/lambda_docker.yml:26` already call bare `setup_remote_docker` with no DLC and build + push multi-arch images on every run across ~40 repos — DLC-less remote Docker already works in this orb.
- The `SetCommandTimeout(30s)` calls in `EventDbStoreTestBase.cs` / `IsolatedDbTestBase.cs` are EF **SQL command** timeouts, not container startup. Image pull happens before the wait strategy clock starts.
- No `WithStartupTimeout`, no `.testcontainers.properties`, no `TESTCONTAINERS_*` overrides in any consumer repo, so Testcontainers defaults apply.
- 10 of 42 repos reference Testcontainers/Docker in test code; the rest pay the surcharge for a daemon their tests never touch.

Net effect for those 10: a cold pull per run, roughly 10–30s, 2–5 credits on `medium`, against 200 saved.

Smoke-tested on `tradeart-metadata-storage` against dev orb `dev:173df83…` on a throwaway branch (test job only, no publish/deploy) — see the comment thread for the result.

## Known risk

Testcontainers pulls `postgres`, `testcontainers/ryuk` and `confluentinc/cp-kafka:7.2.15` **anonymously from Docker Hub** — there is no Hub `docker login` anywhere in the orb (the only `docker login` calls are ECR, and the executors come from `public.ecr.aws`, so they are exempt). DLC currently absorbs some of those pulls, so the failure mode if this ever bites is intermittent `toomanyrequests`, not a hard break.

At current volume this is unlikely but no longer negligible: 1,896 test runs / 90 days ≈ 21/day org-wide, and only the ~10 Testcontainers repos pull, at 2–4 images each — still well under Docker Hub's 100-pulls-per-6h anonymous limit, but it scales with velocity and with pipeline re-run loops. The durable fix, if needed later, is an ECR pull-through cache via `TESTCONTAINERS_HUB_IMAGE_NAME_PREFIX` or a Hub login in the test job — separate follow-up, deliberately not bundled here.

## Scope / notes

- `orb pack` + `orb validate` clean; both jobs verified in the packed output resolving to the parameter with `default: false`.
- Independent of #75 — no overlapping files. #75 adds the same parameter to the new `build_and_test` job but defaults it to `true`, so it banks no DLC saving until every consumer opts in one by one; this PR inverts that for the jobs all 41 repos actually use today.
- `src/jobs/docker.yml` and `src/jobs/lambda_docker.yml` call bare `setup_remote_docker` with no DLC, so they were never paying it — untouched.
- Measurement caveat: CircleCI Insights defaults to the **default branch only**. `all-branches=true` is required or feature-branch pipelines are silently excluded, which undercounts this by ~12×. `goat-sportsbet-api` returned no Insights data and is excluded.
